### PR TITLE
Add ioBroker adapter template project

### DIFF
--- a/iobroker-adapter/.gitignore
+++ b/iobroker-adapter/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+dist/
+*.log
+npm-debug.log*
+package-lock.json
+yarn.lock
+.DS_Store
+

--- a/iobroker-adapter/LICENSE
+++ b/iobroker-adapter/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 MyAdapter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/iobroker-adapter/README.md
+++ b/iobroker-adapter/README.md
@@ -1,0 +1,13 @@
+# ioBroker MyAdapter
+
+A basic ioBroker adapter project created for demonstration purposes.
+
+## Usage
+
+Install dependencies and start the adapter:
+
+```bash
+npm install
+npm start
+```
+

--- a/iobroker-adapter/package.json
+++ b/iobroker-adapter/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "iobroker.myadapter",
+  "version": "0.0.1",
+  "description": "Demo ioBroker adapter",
+  "author": "Your Name <email@example.com>",
+  "license": "MIT",
+  "main": "src/main.js",
+  "scripts": {
+    "start": "node src/main.js",
+    "test": "echo \"No tests specified\""
+  },
+  "keywords": [
+    "ioBroker",
+    "adapter"
+  ],
+  "dependencies": {
+    "@iobroker/adapter-core": "^2.6.5"
+  }
+}

--- a/iobroker-adapter/src/main.js
+++ b/iobroker-adapter/src/main.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const utils = require('@iobroker/adapter-core');
+
+class MyAdapter extends utils.Adapter {
+    constructor(options = {}) {
+        super({
+            ...options,
+            name: 'myadapter',
+        });
+        this.on('ready', this.onReady.bind(this));
+        this.on('unload', this.onUnload.bind(this));
+    }
+
+    onReady() {
+        this.log.info('Adapter is ready');
+    }
+
+    onUnload(callback) {
+        try {
+            callback();
+        } catch (e) {
+            callback();
+        }
+    }
+}
+
+if (module.parent) {
+    module.exports = (options) => new MyAdapter(options);
+} else {
+    (() => new MyAdapter())();
+}


### PR DESCRIPTION
## Summary
- initialize an ioBroker adapter template in a new `iobroker-adapter/` folder
- include basic `package.json`, `src/main.js`, and documentation

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_687cea48b6e083209ce986b96c2304ef